### PR TITLE
[New Feature]: Extended retrial code to support exponential backoff.

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/domain/Retry.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/domain/Retry.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class Retry {
     private Integer max;
     private Integer delay;
+    private String strategy; // New field for "fixed" or "exponential" strategy
     private List<String> withSteps;
 
     public Integer getMax() {
@@ -15,16 +16,19 @@ public class Retry {
         return delay;
     }
 
+    public String getStrategy() {
+        return strategy;
+    }
+
     public List<String> getWithSteps() {
         return withSteps;
     }
     public Retry() {}
 
-    public Retry(Integer max, Integer delay, List<String> withSteps) {
+    public Retry(Integer max, Integer delay, String strategy, List<String> withSteps) {
         this.max = max;
         this.delay = delay;
+        this.strategy = strategy;
         this.withSteps = withSteps;
     }
-
-
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
@@ -267,9 +267,11 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
         boolean retryTillSuccess = false;
         int retryDelay = 0;
         int retryMaxTimes = 1;
+        String retryStrategy = "fixed";
         if (thisStep.getRetry() != null) {
             retryMaxTimes = thisStep.getRetry().getMax();
             retryDelay = thisStep.getRetry().getDelay();
+            retryStrategy = thisStep.getRetry().getStrategy();
             retryTillSuccess = true;
         }
 
@@ -345,7 +347,20 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
                     LOGGER.info("\n---------------------------------------\n" +
                             "        Retry: Attempt number: {}", retryCounter + 2 +
                             "\n---------------------------------------\n");
-                    waitForDelay(retryDelay);
+
+                    if ("exponential".equalsIgnoreCase(retryStrategy)) {
+                        int calculatedDelay = retryDelay * (int) Math.pow(2, retryCounter);
+
+                        // Limit the delay to 10 seconds as a max delay
+                        if (calculatedDelay > 10000) {
+                            calculatedDelay = 10000;
+                        }
+
+                        waitForDelay(calculatedDelay);
+                    }
+                    else {
+                        waitForDelay(retryDelay);
+                    }
 
                     // Set stepOutcomeGreen to true - Not to write report at finally with printToFile().
                     stepOutcomeGreen = true;
@@ -547,7 +562,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
         return executionResult;
     }
 
-    private void waitForDelay(int delay) {
+    public void waitForDelay(int delay) {
         if (delay > 0) {
             try {
                 Thread.sleep(delay);

--- a/core/src/test/java/org/jsmart/zerocode/core/runner/retry/ZeroCodeMultiStepsScenarioRunnerImplExpRetryTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/runner/retry/ZeroCodeMultiStepsScenarioRunnerImplExpRetryTest.java
@@ -1,0 +1,81 @@
+package org.jsmart.zerocode.core.runner;
+
+import org.jsmart.zerocode.core.domain.Retry;
+import org.jsmart.zerocode.core.domain.ScenarioSpec;
+import org.jsmart.zerocode.core.domain.Step;
+import org.jsmart.zerocode.core.engine.preprocessor.ScenarioExecutionState;
+import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessor;
+import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeExternalFileProcessor;
+import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeParameterizedProcessor;
+import org.jsmart.zerocode.core.engine.sorter.ZeroCodeSorter;
+import org.jsmart.zerocode.core.engine.validators.ZeroCodeValidator;
+import org.jsmart.zerocode.core.logbuilder.ZerocodeCorrelationshipLogger;
+import org.jsmart.zerocode.core.runner.ZeroCodeMultiStepsScenarioRunnerImpl;
+import org.jsmart.zerocode.core.utils.ApiTypeUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+public class ZeroCodeMultiStepsScenarioRunnerImplExpRetryTest {
+
+    @Mock
+    private ZeroCodeAssertionsProcessor zeroCodeAssertionsProcessor;
+
+    @Mock
+    private ZeroCodeExternalFileProcessor extFileProcessor;
+
+    @Mock
+    private ZeroCodeParameterizedProcessor parameterizedProcessor;
+
+    @Mock
+    private ZeroCodeSorter sorter;
+
+    @Mock
+    private ApiTypeUtils apiTypeUtils;
+
+    @Mock
+    private ZeroCodeValidator validator;
+
+    @Mock
+    private ZerocodeCorrelationshipLogger correlLogger;
+
+    @InjectMocks
+    private ZeroCodeMultiStepsScenarioRunnerImpl runner;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testExponentialBackoff() throws Exception {
+        // Arrange
+        ScenarioSpec scenarioSpec = mock(ScenarioSpec.class);
+        Step step = mock(Step.class);
+        when(step.getRetry()).thenReturn(new Retry(3, 1000, "exponential", Collections.emptyList()));
+        when(step.getAssertions()).thenReturn(null);
+        when(step.getIgnoreStep()).thenReturn(false);
+        when(scenarioSpec.getSteps()).thenReturn(Collections.singletonList(step));
+        when(parameterizedProcessor.resolveParameterized(any(), anyInt())).thenReturn(scenarioSpec);
+        when(zeroCodeAssertionsProcessor.resolveJsonContent(any(), any())).thenReturn(step);
+        when(extFileProcessor.resolveExtJsonFile(any())).thenReturn(step);
+
+        ScenarioExecutionState scenarioExecutionState = new ScenarioExecutionState();
+        RunNotifier notifier = new RunNotifier();
+        Description description = Description.createTestDescription("test", "testExponentialBackoff");
+
+        // Act
+        runner.runScenario(scenarioSpec, notifier, description);
+
+        // Assert
+        verify(runner, times(3)).waitForDelay(anyInt());
+    }
+}


### PR DESCRIPTION
# Add new Exponential Backoff strategy to Retries within a Step.

## Fixes Issue
- https://github.com/WSU-CptS-581-2025/zerocode/issues/16

## Motivation and Context
For steps that are setup to retry with certain conditions, this adds a new strategy of using Exponential Backoff between retries. This allows the system to lengthen the delay between retries in the case that it may be waiting for a certain result to come back.

## Checklist:

* [x] New Unit tests were added
  * [x] Covered in existing Unit tests

* [x] Integration tests were added
  * [x] Covered in existing Integration tests

* [x] Test names are meaningful

* [x] Feature manually tested and outcome is successful