### PR TITLE
Split up the generateExtentReport to make it more readable and expand…

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/report/ZeroCodeReportGeneratorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/report/ZeroCodeReportGeneratorImpl.java
@@ -83,6 +83,10 @@ public class ZeroCodeReportGeneratorImpl implements ZeroCodeReportGenerator {
         return new ArrayList<>(result.values());
     }
 
+    /**
+     * Generates the Extent report. It creates a new ExtentReports object and processes each report
+     * in the treeReports list to generate the report.
+     */
     @Override
     public void generateExtentReport() {
 
@@ -95,57 +99,107 @@ public class ZeroCodeReportGeneratorImpl implements ZeroCodeReportGenerator {
         linkToSpikeChartIfEnabled();
 
         treeReports.forEach(thisReport -> {
+            processReport(thisReport, extentReports);
+        });
+    }
 
-            thisReport.getResults().forEach(thisScenario -> {
-                ExtentTest test = extentReports.createTest(thisScenario.getScenarioName());
+    /**
+     * Processes the report and generates the Extent report. See referenced functions for detailed steps.
+     *
+     * @param report        The ZeroCodeReport object representing the test report.
+     * @param extentReports The ExtentReports object used to generate the report.
+     */
+    protected void processReport(ZeroCodeReport report, ExtentReports extentReports) {
+        report.getResults().forEach(thisScenario -> {
+            ExtentTest test = extentReports.createTest(thisScenario.getScenarioName());
 
-                 /**This code checks if the scenario has meta data.
-                 If it does, it iterates through each meta data entry and adds it to
-                 the Extent report as an info label.**/
-                if (thisScenario.getMeta() != null) {
-                    for (Map.Entry<String, List<String>> entry : thisScenario.getMeta().entrySet()) {
-                        String key = entry.getKey();
-                        List<String> values = entry.getValue();
-                        test.info(MarkupHelper.createLabel(key + ": " + String.join(", ", values), ExtentColor.BLUE));
-                    }
-                }
+            // Processes any metadata if present
+            processMetaData(test, thisScenario);
 
-                // Assign Category
-                test.assignCategory(DEFAULT_REGRESSION_CATEGORY); //Super set
-                String[] hashTagsArray = optionalCategories(thisScenario.getScenarioName()).toArray(new String[0]);
-                if(hashTagsArray.length > 0) {
-                    test.assignCategory(hashTagsArray); //Sub categories
-                }
+            // Assign Category
+            assignCategory(test, thisScenario);
 
-                // Assign Authors
-                test.assignAuthor(DEFAULT_REGRESSION_AUTHOR); //Super set
-                String[] authorsArray = optionalAuthors(thisScenario.getScenarioName()).toArray(new String[0]);
-                if(authorsArray.length > 0) {
-                    test.assignAuthor(authorsArray); //Sub authors
-                }
+            // Assign Authors
+            assignAuthors(test, thisScenario);
 
-                List<ZeroCodeReportStep> thisScenarioUniqueSteps = getUniqueSteps(thisScenario.getSteps());
-                thisScenarioUniqueSteps.forEach(thisStep -> {
-                    test.getModel().setStartTime(utilDateOf(thisStep.getRequestTimeStamp()));
-                    test.getModel().setEndTime(utilDateOf(thisStep.getResponseTimeStamp()));
+            // Extract the individual test steps
+            extractSteps(test, thisScenario, extentReports);
+        });
+    }
 
-                    final Status testStatus = thisStep.getResult().equals(RESULT_PASS) ? Status.PASS : Status.FAIL;
+    /**
+     * Processes the metadata of a scenario and adds it to the Extent report.
+     * @param test
+     * @param scenario
+     */
+    protected void processMetaData(ExtentTest test, ZeroCodeExecResult scenario) {
+        /**This code checks if the scenario has meta data.
+             If it does, it iterates through each meta data entry and adds it to
+             the Extent report as an info label.**/
+        if (scenario.getMeta() != null) {
+            for (Map.Entry<String, List<String>> entry : scenario.getMeta().entrySet()) {
+                String key = entry.getKey();
+                List<String> values = entry.getValue();
+                test.info(MarkupHelper.createLabel(key + ": " + String.join(", ", values), ExtentColor.BLUE));
+            }
+        }
+    }
 
-                    ExtentTest step = test.createNode(thisStep.getName(), TEST_STEP_CORRELATION_ID + " " + thisStep.getCorrelationId());
+    /**
+     * Assigns categories to the test case in the Extent report.
+     * @param test
+     * @param scenario
+     */
+    protected void assignCategory(ExtentTest test, ZeroCodeExecResult scenario) {
+        // Assign Category
+        test.assignCategory(DEFAULT_REGRESSION_CATEGORY); //Super set
+        String[] hashTagsArray = optionalCategories(scenario.getScenarioName()).toArray(new String[0]);
+        if(hashTagsArray.length > 0) {
+            test.assignCategory(hashTagsArray); //Sub categories
+        }
+    }
 
-                    if (testStatus.equals(Status.PASS)) {
-                        step.pass(thisStep.getResult());
-                    } else {
-                        step.info(MarkupHelper.createCodeBlock(thisStep.getOperation() + "\t" + thisStep.getUrl()));
-                        step.info(MarkupHelper.createCodeBlock(thisStep.getRequest(), CodeLanguage.JSON));
-                        step.info(MarkupHelper.createCodeBlock(thisStep.getResponse(), CodeLanguage.JSON));
-                        step.fail(MarkupHelper.createCodeBlock("Reason:\n" + thisStep.getAssertions()));
-                    }
-                    extentReports.flush();
-                });
+    /**
+     * Assigns authors to the test case in the Extent report.
+     * @param test
+     * @param scenario
+     */
+    protected void assignAuthors(ExtentTest test, ZeroCodeExecResult scenario) {
+        // Assign Authors
+        test.assignAuthor(DEFAULT_REGRESSION_AUTHOR); //Super set
+        String[] authorsArray = optionalAuthors(scenario.getScenarioName()).toArray(new String[0]);
+        if(authorsArray.length > 0) {
+            test.assignAuthor(authorsArray); //Sub authors
+        }
+    }
 
-            });
+    /**
+     * Extracts the steps from the scenario and creates a node for each step in the Extent report.
+     * It also sets the start and end time for each step based on the request and response timestamps.
+     *
+     * @param test              The ExtentTest object representing the test case.
+     * @param scenario          The ZeroCodeExecResult object representing the scenario.
+     * @param extentReports     The ExtentReports object used to generate the report.
+     */
+    protected void extractSteps(ExtentTest test, ZeroCodeExecResult scenario, ExtentReports extentReports) {
+        List<ZeroCodeReportStep> thisScenarioUniqueSteps = getUniqueSteps(scenario.getSteps());
+        thisScenarioUniqueSteps.forEach(thisStep -> {
+            test.getModel().setStartTime(utilDateOf(thisStep.getRequestTimeStamp()));
+            test.getModel().setEndTime(utilDateOf(thisStep.getResponseTimeStamp()));
 
+            final Status testStatus = thisStep.getResult().equals(RESULT_PASS) ? Status.PASS : Status.FAIL;
+
+            ExtentTest step = test.createNode(thisStep.getName(), TEST_STEP_CORRELATION_ID + " " + thisStep.getCorrelationId());
+
+            if (testStatus.equals(Status.PASS)) {
+                step.pass(thisStep.getResult());
+            } else {
+                step.info(MarkupHelper.createCodeBlock(thisStep.getOperation() + "\t" + thisStep.getUrl()));
+                step.info(MarkupHelper.createCodeBlock(thisStep.getRequest(), CodeLanguage.JSON));
+                step.info(MarkupHelper.createCodeBlock(thisStep.getResponse(), CodeLanguage.JSON));
+                step.fail(MarkupHelper.createCodeBlock("Reason:\n" + thisStep.getAssertions()));
+            }
+            extentReports.flush();
         });
     }
 

--- a/core/src/test/java/org/jsmart/zerocode/core/report/ZeroCodeReportGeneratorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/report/ZeroCodeReportGeneratorImplTest.java
@@ -1,22 +1,29 @@
 package org.jsmart.zerocode.core.report;
 
+import com.aventstack.extentreports.ExtentReports;
+import com.aventstack.extentreports.ExtentTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
+import org.jsmart.zerocode.core.domain.reports.ZeroCodeExecResult;
+import org.jsmart.zerocode.core.domain.reports.ZeroCodeReport;
 import org.jsmart.zerocode.core.domain.reports.ZeroCodeReportStep;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.jsmart.zerocode.core.constants.ZeroCodeReportConstants.RESULT_FAIL;
 import static org.jsmart.zerocode.core.constants.ZeroCodeReportConstants.RESULT_PASS;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ZeroCodeReportGeneratorImplTest {
 
@@ -173,4 +180,56 @@ public class ZeroCodeReportGeneratorImplTest {
 
     }
 
+    @Test
+    public void shouldProcessReportAndAssignMetadata() {
+        // Arrange
+        ZeroCodeReport mockReport = mock(ZeroCodeReport.class);
+        ZeroCodeExecResult mockScenario = mock(ZeroCodeExecResult.class);
+        ExtentReports mockExtentReports = mock(ExtentReports.class);
+        ExtentTest mockTest = mock(ExtentTest.class);
+
+        when(mockReport.getResults()).thenReturn(Collections.singletonList(mockScenario));
+        when(mockScenario.getScenarioName()).thenReturn("Test Scenario");
+        when(mockExtentReports.createTest(anyString())).thenReturn(mockTest);
+
+        // Act
+        zeroCodeReportGenerator.processReport(mockReport, mockExtentReports);
+
+        // Assert
+        verify(mockExtentReports).createTest("Test Scenario");
+        verify(mockTest).assignCategory(anyString());
+        verify(mockTest).assignAuthor(anyString());
+    }
+
+    @Test
+    public void shouldAssignDefaultAndOptionalCategories() {
+        // Arrange
+        ExtentTest mockTest = mock(ExtentTest.class);
+        ZeroCodeExecResult mockScenario = mock(ZeroCodeExecResult.class);
+
+        when(mockScenario.getScenarioName()).thenReturn("Test Scenario #Category1 #Category2");
+
+        // Act
+        zeroCodeReportGenerator.assignCategory(mockTest, mockScenario);
+
+        // Assert
+        verify(mockTest).assignCategory("Regression");
+        verify(mockTest).assignCategory("#Category1", "#Category2");
+    }
+
+    @Test
+    public void shouldAssignDefaultAndOptionalAuthors() {
+        // Arrange
+        ExtentTest mockTest = mock(ExtentTest.class);
+        ZeroCodeExecResult mockScenario = mock(ZeroCodeExecResult.class);
+
+        when(mockScenario.getScenarioName()).thenReturn("Test Scenario @Author1 @Author2");
+
+        // Act
+        zeroCodeReportGenerator.assignAuthors(mockTest, mockScenario);
+
+        // Assert
+        verify(mockTest).assignAuthor("All");
+        verify(mockTest).assignAuthor("@Author1", "@Author2");
+    }
 }


### PR DESCRIPTION
# Split up the generateExtentReport() function to make it more readable and expandable

PR Branch
https://github.com/WSU-CptS-581-2025/zerocode/tree/jml/deliverable_2/improvement_2

## Checklist:

* [x] New Unit tests were added
  * [x] Covered in existing Unit tests

* [ ] Integration tests were added
  * [ ] Covered in existing Integration tests

* [x] Test names are meaningful

* [x] Feature manually tested and outcome is successful